### PR TITLE
Update deploy-pre-release.yml

### DIFF
--- a/.github/workflows/deploy-pre-release.yml
+++ b/.github/workflows/deploy-pre-release.yml
@@ -121,6 +121,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish pre-release to pypi
+        if: github.repository == 'eclipse-volttron/volttron-core'
         run: |
           poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
           poetry publish

--- a/.github/workflows/deploy-pre-release.yml
+++ b/.github/workflows/deploy-pre-release.yml
@@ -121,9 +121,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish pre-release to pypi
-        if: github.repository == 'VOLTTRON/volttron-core'
         run: |
-          # poetry config repositories.test-pypi https://test.pypi.org/legacy/
-          # poetry config pypi-token.test-pypi ${{ secrets.TEST_PYPI_TOKEN }}
           poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
-          poetry publish # -r test-pypi
+          poetry publish


### PR DESCRIPTION
The deploy-pre-release workflow only publishes to PyPi when the repo is named "VOLTTRON/volttron-core". But this repo is named "eclipse-volttron/volttron-core" and thus the workflow will not publish the prerelease to PyPi. See this workflow:  https://github.com/eclipse-volttron/volttron-core/runs/7884946983?check_suite_focus=true. Although it shows green, the workflow did not publish the prerelease to PyPi as verified in https://pypi.org/project/volttron/#history. 

This PR resolves the problem by removing the condition that the repo needs to have a certain name in order to publish to PyPi. It also removes some commented code that is no longer needed. 