### PR TITLE
Add poetry dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
+poetry = "^1.2.2"
 python = "^3.8"
 pyzmq = "^22.3.0"
 gevent = "^21.12.0"


### PR DESCRIPTION
* Addresses issue in https://github.com/eclipse-volttron/volttron-openadr-ven/issues/50#issuecomment-1414200470
* Add poetry dependency to pyproject.toml so that 'vctl install' can succeed for agents such as volttron-openadr-ven. Currently, when trying to install volttron-openadr-ven onto the volttron platform, the platform silently fails the installation and prints "2" to standard out after running `vctl install volttron-opendadr-ven --agent-config <path to config>`
* @shwethanidd and @kefeimo have reported the same issue when trying to install this agent on the platform
* After installing 'poetry' in the virtual environment, installing this agent does succeed. 