### PR TITLE
Python 11 update

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,7 +21,7 @@ defaults:
 env:
   LANG: en_US.utf-8
   LC_ALL: en_US.utf-8
-  PYTHON_VERSION: '3.8'
+  PYTHON_VERSION: '3.10'
   PROJECT_NAME: volttron-core
 
 jobs:
@@ -29,8 +29,8 @@ jobs:
   run-tests:
     strategy:
       matrix:
-        os: ["ubuntu-20.04", "ubuntu-22.04"]
-        python: ["3.8", "3.9", "3.10"]
+        os: ["ubuntu-22.04"]
+        python: ["3.10", "3.11"]
 
     runs-on: ${{ matrix.os }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,8 @@ classifiers = [
     "Intended Audience :: Education",
     "Intended Audience :: Developers",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
 
@@ -25,9 +24,9 @@ packages = [
 
 [tool.poetry.dependencies]
 poetry = "^1.2.2"
-python = "^3.8"
-pyzmq = "^22.3.0"
-gevent = "^21.12.0"
+python = "^3.10"
+pyzmq = "^25.0.2"
+gevent = "^22.10.2"
 PyYAML = "^6.0"
 toml = "^0.10.2"
 dateutils = "^0.6.12"
@@ -37,7 +36,7 @@ cryptography = "^36.0.1"
 watchdog-gevent = "^0.1.1"
 pip = "22.2.2"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^6.2.5"
 mock = "^4.0.3"
 pre-commit = "^2.17.0"


### PR DESCRIPTION
Updated pyzmq and gevent version pins to support Python 3.11.  Also updated testing versions in github workflows.

Fixes #90. 

Once this issue is merged, volttron-testing will need to be updated with the new version number for volttron-core in PyPi and a pull request made for that respository.