### PR TITLE
Fixed uncaught exception when host is unreachable.

### DIFF
--- a/src/volttron/client/vip/agent/errors.py
+++ b/src/volttron/client/vip/agent/errors.py
@@ -44,7 +44,10 @@ class VIPError(Exception):
 
     @classmethod
     def from_errno(cls, errnum, msg, *args):
-        errnum = int(errnum)
+        try:
+            errnum = getattr(errno, errnum.split('.')[-1])
+        except ValueError:
+            return cls(999, msg, *args)
         return {
             errno.EHOSTUNREACH: Unreachable,
             errno.EAGAIN: Again,


### PR DESCRIPTION
Fixes case where an unreachable host causes an uncaught exception that takes down the vip loop.

Calling a non-existent agent is one example of an event which could cause this, #174 is likely to be fixed by this PR as well.
