### PR TITLE
Fixed #229

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "volttron-core"
-version = "2.0.0rc0"
+version = "2.0.0rc1"
 description = "VOLTTRON™ is an open source platform for distributed sensing and control. The platform provides services for collecting and storing data from buildings and devices and provides an environment for developing applications which interact with that data."
 authors = ["volttron <volttron@pnnl.gov>"]
 license = "Apache-2.0"
@@ -23,10 +23,13 @@ packages = [
     { include = "volttron/py.typed", from = "src" }
 ]
 
+[tool.poetry.group.dev]
+optional = true
+
 [tool.poetry.dependencies]
 poetry = "^1.8.2"
 python = "^3.10"
-gevent = "^24.2.1"
+gevent = ">=24.2.1,<24.3"
 PyYAML = "^6.0"
 toml = "^0.10.2"
 dateutils = "^0.6.12"

--- a/src/volttron/server/__main__.py
+++ b/src/volttron/server/__main__.py
@@ -76,7 +76,7 @@ for arg in sys.argv:
         # Finally set the logging parameter to the absolute path
         sys.argv[index + 1] = logging_config.absolute().as_posix()
 
-    total_count += vcount
+        total_count += vcount
 
 logging.config.dictConfig(get_default_logging_config(level=total_count))
 


### PR DESCRIPTION
This PR fixes a logging issue that invalidates the -v option to volttron.  This was caused by an incorrect indent in the core code.  I have incremented the version tag so that it can be pushed to pypi as soon as it is merged.