### PR TITLE
Added keyword to account for changes in watchdog API.

### DIFF
--- a/src/volttron/utils/filewatch.py
+++ b/src/volttron/utils/filewatch.py
@@ -49,7 +49,7 @@ class VolttronHomeFileReloader(PatternMatchingEventHandler):
     """
 
     def __init__(self, filetowatch, callback):
-        super(VolttronHomeFileReloader, self).__init__([f"{cc.get_volttron_home()}/{filetowatch}"])
+        super(VolttronHomeFileReloader, self).__init__(patterns=[f"{cc.get_volttron_home()}/{filetowatch}"])
         _log.debug(f"patterns is {cc.get_volttron_home()}/{filetowatch}")
         self._callback = callback
 
@@ -71,7 +71,7 @@ class AbsolutePathFileReloader(PatternMatchingEventHandler):
     """
 
     def __init__(self, filetowatch, callback):
-        super(AbsolutePathFileReloader, self).__init__([filetowatch])
+        super(AbsolutePathFileReloader, self).__init__(patterns=[filetowatch])
         self._callback = callback
         self._filetowatch = filetowatch
 


### PR DESCRIPTION
Added a keyword to the super calls in VolttronHomeFileReloader and AbsolutePathFileReloader to account for changes in the watchdog API which now require keyword arguments.

This is identical to a fix in monolithic PR 3205 and fixes equivalent of monolithic issue 3200.