### PR TITLE
Feature/251 logs arent showing up

### DIFF
--- a/logging_config.yml
+++ b/logging_config.yml
@@ -1,0 +1,29 @@
+version: 1
+disable_existing_loggers: False
+
+formatters:
+  simple:
+    format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+handlers:
+  console:
+    class: logging.StreamHandler
+    level: DEBUG
+    formatter: simple
+    stream: ext://sys.stdout
+
+  file:
+    class: logging.FileHandler
+    level: INFO
+    formatter: simple
+    filename: "${VOLTTRON_HOME}/volttron.log"
+
+loggers:
+  volttron:
+    level: DEBUG
+    handlers: [file]
+    propagate: no
+  
+root:
+  level: WARNING
+  handlers: [console]

--- a/src/volttron/server/__main__.py
+++ b/src/volttron/server/__main__.py
@@ -91,18 +91,20 @@ if os.environ.get("VOLTTRON_HOME") is None:
 os.makedirs(os.path.join(os.environ["VOLTTRON_HOME"]), exist_ok=True)
 
 if logging_config and total_count > 0:
-    sys.stderr.write("Cannot specify both --log-config and --verbose options")
+    sys.stderr.write("Cannot specify both --log-config and --verbose options\n"
+                     "Update the logging config file to set the verbosity level")
     sys.exit(1)
 
 if logging_config and file_to_log_to:
-    sys.stderr.write("Cannot specify both --log and --log-config options")
+    sys.stderr.write("Cannot specify both --log and --log-config options\n"
+                     "Update the logging config file to specify the log file")
     sys.exit(1)
 
 # If the user has specified a logging configuration then allow them full access to all the
 # responsibility of logging.
 if logging_config:
     configure_logging(logging_config)
-    
+
 else:
     # The user wants to output all to a file so we can do that for them.
     if file_to_log_to:

--- a/src/volttron/server/logs.py
+++ b/src/volttron/server/logs.py
@@ -53,6 +53,7 @@ import os
 import inspect
 import logging
 import os
+from pathlib import Path
 import stat
 import sys
 import syslog
@@ -304,6 +305,8 @@ def configure_logging(conf_path):
 
     YAML formatted configuration files require the PyYAML package.
     """
+    if isinstance(conf_path, Path):
+        conf_path = conf_path.as_posix()
 
     conf_format = "ini"
     if conf_path.startswith("ini:"):

--- a/src/volttron/server/logs.py
+++ b/src/volttron/server/logs.py
@@ -320,6 +320,8 @@ def configure_logging(conf_path):
         conf_format = "py"
     elif conf_path.endswith(".yaml"):
         conf_format = "yaml"
+    elif conf_path.endswith(".yml"):
+        conf_format = "yaml"
 
     if conf_format == "ini":
         try:
@@ -351,7 +353,8 @@ def configure_logging(conf_path):
                     "loading logging configuration from a YAML file.",
                 )
             try:
-                conf_dict = yaml.safe_load(conf_file.read())
+                expanded_conf = os.path.expanduser(os.path.expandvars(conf_file.read()))
+                conf_dict = yaml.safe_load(expanded_conf)
             except yaml.YAMLError as exc:
                 return conf_path, exc
     try:


### PR DESCRIPTION
#212 #251 

- Shows an example log config that is passed with -L logging_config.yml
- Fix yml files weren't being correctly recognized due to yaml file extension issue
- Update behavior so that -v (verboseness) and -L are mutually exclusive.  So is -l and -L.