### PR TITLE
refactor: update poetry dependency version and fix argument parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ include = [
 optional = true
 
 [tool.poetry.dependencies]
-poetry = ">=2.0,<3.0"
+poetry = "^2.0"
 python = "^3.10"
 gevent = ">=24.2.1,<24.3"
 PyYAML = "^6.0"

--- a/src/volttron/server/server_argparser.py
+++ b/src/volttron/server/server_argparser.py
@@ -385,7 +385,7 @@ class ArgumentParser(_argparse.ArgumentParser):
                 cli_args.append(arg_string)
                 continue
             # Some kind of option was encountered, so deal with it
-            action, option_string, explicit_arg = option_tuple
+            action, option_string, sep, explicit_arg = option_tuple
             if explicit_arg is not None:
                 args = [explicit_arg]
             elif action.nargs in [_argparse.REMAINDER, _argparse.PARSER]:

--- a/src/volttron/server/server_options.py
+++ b/src/volttron/server/server_options.py
@@ -104,8 +104,6 @@ class ServerOptions:
 
             if isinstance(self.address, str):
                 self.address = [self.address]
-            elif not self.address:
-                self.address = ["tcp://127.0.0.1:22916"]
 
         else:
             if not self.initialized:


### PR DESCRIPTION
This pull request fixes #267 and #266.  The vip-address 127.0.0.1:22916 should not be automatically used, but the local ipc address within the volttron_home should be used. 

The user will then update the config file adding vip-address to the config file to expose the ip based connection.

Closes #267 #266