### PR TITLE
using GITHUB_TOKEN as only that is available for PR from forks

### DIFF
--- a/.github/workflows/deploy-pre-release.yml
+++ b/.github/workflows/deploy-pre-release.yml
@@ -18,11 +18,10 @@ env:
   PYTHON_VERSION: '3.10'
   OWNER: eclipse-volttron
 
+permissions:
+  contents: write
+
 jobs:
   deploy-pre-release:
     if: ${{ github.event.pull_request.merged && ! startsWith(github.ref_name, 'releases/') && github.ref_name != 'main' && ! contains(github.event.pull_request.labels.*.name, 'documentation') }}
     uses: eclipse-volttron/github-tooling/.github/workflows/deploy-pre-release.yml@main
-    secrets: 
-      #inherit
-      git-token: ${{ secrets.AUTO_PROJECT_PAT }}
-      pypi-token: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Only GITHUB_TOKEN are passed to reusable workflows for actions that run on PR from a fork. ( [Refer issue](https://github.com/actions/runner/discussions/3039) ) 
PR from different branches of the same repo can pass other tokens but not PR from forks. So explicitly setting write permission for GITHUB_TOKEN