### PR TITLE
better dynamic loading of auth implementations that are in zmq lib.

### DIFF
--- a/src/volttron/client/commands/authz_parser.py
+++ b/src/volttron/client/commands/authz_parser.py
@@ -9,8 +9,7 @@ from volttron.utils.context import ClientContext as cc
 import volttron.types.auth.authz_types as authz
 
 # Note: rpc call in volttron-lib-auth/src/volttron/services/auth/auth_service.py
-from volttron.services.auth.auth_service import AUTH, VolttronAuthService
-from volttron.utils.jsonrpc import RemoteError
+from volttron.auth.auth_service import AUTH, VolttronAuthService
 
 
 def add_authz_parser(add_parser_fn, filterable):

--- a/src/volttron/server/containers.py
+++ b/src/volttron/server/containers.py
@@ -175,6 +175,9 @@ class Container:
 
     def _resolve_arguments(self, fn: callable, **kwargs) -> Result[dict, None]:
         if inspect.isclass(fn):
+            # TODO: get_type_hints returns all params.
+            #  Add logic to skip optional args based on what is enabled
+            #  i.e. auth related class can be missing if auth is not enabled
             required_args = get_type_hints(fn.__init__)
         else:
             required_args = get_type_hints(fn)
@@ -300,7 +303,8 @@ class Container:
                 # the resovable services.
                 resolved_kwargs: Result[dict, None] = self._container._resolve_arguments(
                     self._value.__init__, **self._kwargs)
-
+                if isinstance(resolved_kwargs, Failure):
+                    raise ResolutionError(str(resolved_kwargs))
                 # required_args = get_type_hints(self._value.__init__)
 
                 # _log.debug(f"Required args are: {required_args}")

--- a/src/volttron/server/run_server.py
+++ b/src/volttron/server/run_server.py
@@ -290,17 +290,17 @@ def start_volttron_process(options: ServerOptions):
     from volttron.loader import load_subclasses, find_subpackages
     load_subclasses("volttron.types.MessageBus", "volttron.messagebus")
     if opts.auth_enabled:
-        import volttron.services.auth
+        # Shouldn't default VolttronAuthService impl of AuthService also be loaded dynamically?
+        # If so it should be moved to volttron.auth and not be in volttron.services.auth
+        #import volttron.services.auth
         # Load the package
         auth_pkg = importlib.import_module('volttron.types.auth')
         # Access the __all__ attribute
         base_auth_classes = getattr(auth_pkg, '__all__', None)
         # load classes from volttron-lib-auth + any packages defined by additional libraries
-        subpackages = find_subpackages("volttron.auth")
         for cls in base_auth_classes:
             load_subclasses('volttron.types.auth.'+cls, "volttron.auth")
-            for p in subpackages:
-                load_subclasses('volttron.types.auth.'+cls, p)
+
 
     aip_platform = service_repo.resolve(aip.AIPplatform)
     aip_platform.setup()
@@ -332,7 +332,6 @@ def start_volttron_process(options: ServerOptions):
         from volttron.server.decorators import start_service_agents
         from volttron.services.config_store.config_store_service import \
             ConfigStoreService
-        from volttron.types.auth import CredentialsStore
         from volttron.services.control.control_service import ControlService
         from volttron.services.health.health_service import HealthService
         from volttron.types.known_host import \

--- a/src/volttron/types/auth/__init__.py
+++ b/src/volttron/types/auth/__init__.py
@@ -16,5 +16,5 @@ class AuthException(Exception):
 __all__: list[str] = [
     "Credentials", "PublicCredentials", "PKICredentials", "CredentialStoreError", "InvalidCredentials",
     "IdentityAlreadyExists", "IdentityNotFound", "AuthService", "Authorizer", "Authenticator", "CredentialsCreator",
-    "CredentialsFactory", "VolttronCredentials", "AuthException", "AuthorizationManager"
+    "CredentialsFactory", "CredentialsStore", "VolttronCredentials", "AuthException", "AuthorizationManager"
 ]


### PR DESCRIPTION
better dynamic loading of auth implementations that are in zmq lib. More generic load subclass methods that correctly parse subpackages that can be at more than 1 level below the mandatory prefix. For example, zmq can now have auth implementation classes in volttron.auth.zmq.zap.something and it will get loaded correctly.  This will work even volttron core has a volttron.auth.<some module>. 