### PR TITLE
Set default timeout to 120 seconds in control.py

### DIFF
--- a/src/volttron/client/commands/control.py
+++ b/src/volttron/client/commands/control.py
@@ -2148,6 +2148,7 @@ def main():
         "--timeout",
         type=float,
         metavar="SECS",
+        timeout=120.0,
         help="timeout in seconds for remote calls (default: %(default)g)",
     )
     global_args.add_argument(


### PR DESCRIPTION
Fixes #294 handling the timeout error does fix the issue with the publish not having enough args.