### PR TITLE
core changes based on testing for plaformwrapper

### DIFF
--- a/src/volttron/client/commands/control.py
+++ b/src/volttron/client/commands/control.py
@@ -634,8 +634,6 @@ def status_agents(opts):
             agent_user = ""
         try:
             agent = all_agents[uuid]
-            print(f"Agent user is {agent_user}")
-            print(f"agent is {agent}")
             all_agents[uuid] = agent
         except KeyError:
             all_agents[uuid] = AgentMeta(name=name, uuid=uuid, identity=identity, agent_user=agent_user)

--- a/src/volttron/client/commands/subscribe_parser.py
+++ b/src/volttron/client/commands/subscribe_parser.py
@@ -43,7 +43,7 @@ def subscribe_to_bus(opts):
         event = gevent.event.Event()
         greenlet = gevent.spawn(agent.core.run, event)
         event.wait()
-
+        #print(f"Subscribing to {opts.topic} address {opts.address} with identity {opts.identity_stage}")
         agent.vip.pubsub.subscribe('pubsub', prefix=opts.topic, callback=on_message, all_platforms=opts.all_platforms).get(1)
 
         try:
@@ -54,9 +54,9 @@ def subscribe_to_bus(opts):
         finally:
             print("Stopping Subscriptions")
             agent.core.stop()
-        
+
         sys.exit()
-               
+
 
     conn = opts.connection
     count = 0
@@ -71,30 +71,30 @@ def subscribe_to_bus(opts):
             subscription_identity = f"subscriber{count}"
             continue
         break
-    
+
     # print(opts)
     # print(sys.executable)
     # print(sys.argv)
-    # print(f"Creating credentials for {subscription_identity}")
+    #print(f"Creating credentials for {subscription_identity}")
     # We need to create new credentials or have one that is created already for us.
     value = conn.server.vip.rpc.call(AUTH, "create_credentials", identity=subscription_identity).get(timeout=4)
     args = sys.argv.copy()
     args.extend(['--identity-stage', subscription_identity])
-    
+
     # This process will now execute in the currently executing process.  It is not like
     # subprocess in that it will not exit until the process ends.
     os.execvp(args[0], args=args)
 
 
-    
+
     #opts.connection.server.vip.pubsub.publish("pubsub", topic=opts.topic, message=opts.data).get()
 
 def add_subscribe_parser(add_parser_fn):
 
     subscriber = add_parser_fn("subscribe", help="Allow a subscription to listen to the bus and print out responses.")
-    
+
     #publisher_subparser = publisher.add_subparsers(title="publish options")
-    
+
     subscriber.add_argument("topic", help="Topic to publish to")
     subscriber.add_argument("--all-platforms", action="store_true",
                             help="Subscribe to all platforms for this topic/prefix")

--- a/src/volttron/client/decorators.py
+++ b/src/volttron/client/decorators.py
@@ -130,6 +130,16 @@ def get_connection_builder(name: Optional[str] = None) -> ConnectionBuilder:
     return __get_class_from_factory__(registration=connection_builder, name=name)
 
 
+def reset_core_builder():
+    """Reset the cached CoreBuilder singleton so the next call to
+    get_core_builder() creates a fresh instance with empty per-instance state
+    (e.g. agent_contexts, connection_builders on ZmqCoreBuilder).
+    Call this whenever a new isolated server context is needed (e.g. between
+    PlatformWrapper instances in tests)."""
+    global __core_builder__
+    __core_builder__ = None
+
+
 def get_server_credentials(address: Optional[str] = None) -> Credentials:
     import os
     from pathlib import Path

--- a/src/volttron/server/aip.py
+++ b/src/volttron/server/aip.py
@@ -549,7 +549,7 @@ class AIPplatform:
 
             # will reuse credentials and capabilities if already exists.
             # Else will create new creds and default capabilities
-            self._auth_service.create_agent(identity=final_identity)
+            self._auth_service.create_credentials(identity=final_identity)
 
             # if self.message_bus == "rmq":
             #     rmq_user = cc.get_fq_identity(final_identity, cc.get_instance_name())

--- a/src/volttron/server/containers.py
+++ b/src/volttron/server/containers.py
@@ -75,6 +75,10 @@ class Container:
         Container.containers[name] = self
         self._resolvable: dict[T, S] = {}
         self._resolvable_lists: dict[T, Container.ResolvableList] = {}
+        # Tracks only class-based registrations (Singleton/ResolvableList/Transient).
+        # Never mutated after a registration is added, so reset_instances() can
+        # restore _resolvable to the factory state without losing class definitions.
+        self._registrations: dict[T, S] = {}
 
     def print_resolved(self, stream=sys.stdout):
         stream.write(f'{"-" * 80}\n')
@@ -89,7 +93,7 @@ class Container:
             stream.write("Singletons")
             for r, v in self._resolvable.items():
                 stream.write(f"\t{r}-> {v}\n")
-            
+
         else:
             stream.write("No resolved items found")
         stream.write(f'{"-" * 80}\n')
@@ -433,6 +437,7 @@ class Container:
         if type in self._resolvable:
             raise AttributeError(f"Type: {type} already exists and can't be modified.")
         self._resolvable[type] = Container.Singleton(self, value, **kwargs)
+        self._registrations[type] = self._resolvable[type]
 
     def add_concrete_reference(self, type: T, value: S, **kwargs: dict):
 
@@ -449,12 +454,18 @@ class Container:
         if not type in self._resolvable_lists:
             self._resolvable_lists[type] = resolvable_list
         resolvable_list.add_singleton(value, Container.Singleton(self, value, **kwargs))
+        # Always point _registrations at the (possibly updated) ResolvableList so that
+        # reset_instances() can restore it even after resolve() has overwritten it.
+        self._registrations[type] = self._resolvable[type]
 
     def add_instance(self, type: T, value: S):
+        # Direct instances are NOT recorded in _registrations so that
+        # reset_instances() removes them (forcing the caller to re-supply them).
         self._resolvable[type] = value
 
     def add_factory(self, type: T, value: S, **kwargs):
         self._resolvable[type] = Container.Transient(value, **kwargs)
+        self._registrations[type] = self._resolvable[type]
 
     def resolve(self, type: T, **kwargs) -> Optional[S]:
         _log.debug(f"Attempting resolve of type: {type}")
@@ -497,6 +508,41 @@ class Container:
                     if v.contains(type):
                         return v.retrieve(type)
             raise Unresolvable(type=type)
+
+    def reset_instances(self):
+        """Clear all resolved live-object caches and direct add_instance values.
+
+        After this call the container is back to its class-registration state:
+        every subsequent resolve() will build a fresh instance, picking up any
+        new add_instance() values (e.g. a new ServerOptions for a new
+        VOLTTRON_HOME).  Class-registrations made via add_interface_reference,
+        add_concrete_reference, and add_factory are preserved.
+
+        Call this whenever a new "context" (e.g. a new PlatformWrapper with its
+        own volttron_home) is being set up so that stale singletons from the
+        previous context are not reused.
+        """
+        # Step 1: Remove from _resolvable any key that is not a class-registration.
+        # This covers:
+        #   - Direct add_instance values (e.g. ServerOptions instances)
+        #   - Live objects cached by resolve() that replaced a Singleton entry
+        keys_to_remove = [k for k in list(self._resolvable) if k not in self._registrations]
+        for k in keys_to_remove:
+            del self._resolvable[k]
+
+        # Step 2: Restore any registration entry whose _resolvable slot was
+        # overwritten by a cached live object from a previous resolve() call.
+        for k, v in self._registrations.items():
+            self._resolvable[k] = v
+
+        # Step 3: Clear the _resolved cache on every Singleton so the next
+        # resolve() call re-instantiates with fresh dependencies.
+        for entry in self._resolvable.values():
+            if isinstance(entry, Container.Singleton):
+                entry._resolved = None
+        for rl in self._resolvable_lists.values():
+            for singleton in rl._resolvers.values():
+                singleton._resolved = None
 
     @staticmethod
     def create(name: str) -> Container:

--- a/src/volttron/server/run_server.py
+++ b/src/volttron/server/run_server.py
@@ -244,7 +244,7 @@ def start_volttron_process(options: ServerOptions):
             # Disable federation to prevent further attempts
             opts.enable_federation = False
             sys.exit(1)
-            
+
 
     # vip_address is meant to be a list so make it so.
     if not isinstance(opts.address, list):
@@ -545,6 +545,15 @@ def start_volttron_process(options: ServerOptions):
         _log.error(traceback.print_exc())
     finally:
         _log.debug("AIP finally")
+        # Stop the authenticator so its inproc socket and greenlet are released
+        # cleanly rather than waiting for process exit.
+        if options.auth_enabled:
+            try:
+                from volttron.types.auth import Authenticator
+                _authenticator = service_repo.resolve(Authenticator)
+                _authenticator.stop()
+            except Exception:
+                _log.exception("Failed to stop authenticator cleanly")
         opts.aip.finish()
         instance_file = str(VOLTTRON_INSTANCES_PATH)
         try:

--- a/src/volttron/types/auth/auth_service.py
+++ b/src/volttron/types/auth/auth_service.py
@@ -41,11 +41,24 @@ class Authenticator(ABC):
     def is_authenticated(self, *, identity: authz.Identity) -> bool:
         ...
 
+    def stop(self) -> None:
+        """Release any resources held by this authenticator.
+
+        Implementations that hold sockets, threads, or greenlets MUST
+        override this and release them.  The default is a no-op so that
+        implementations that need no teardown don't have to override it.
+        """
+        ...
+
 
 class AuthorizationManager:
 
     @abstractmethod
     def get_protected_rpcs(self, identity: authz.Identity) -> list[str]:
+        ...
+
+    def reload(self) -> None:
+        """Re-read persisted authz state into memory. No-op by default."""
         ...
 
     @abstractmethod
@@ -141,9 +154,6 @@ class AuthorizationManager:
 class AuthService(Service):
 
     # Authentication
-    @abstractmethod
-    def create_agent(self, *, identity: str, **kwargs) -> bool:
-        ...
 
     @abstractmethod
     def remove_agent(self, *, identity: str, **kwargs) -> bool:

--- a/src/volttron/types/auth/authz_types.py
+++ b/src/volttron/types/auth/authz_types.py
@@ -714,9 +714,12 @@ class VolttronAuthzMap:
         return True
 
     def get_protected_rpcs(self, identity) -> list[str]:
+        if identity not in self.agent_capabilities:
+            raise ValueError(f"################# Invalid agent identity {identity} agent capabilities is {self.agent_capabilities}")
         id_authz = self.agent_capabilities.get(identity)
         if not id_authz:
-            raise ValueError(f"Invalid agent identity {identity}")
+            print(f"No agent capabilities found for identity {identity}")
+            return []
         return id_authz.get("protected_rpcs", [])
 
     def create_protected_topics(self, *, topic_name_patterns: list[str]) -> bool:

--- a/src/volttron/utils/commands.py
+++ b/src/volttron/utils/commands.py
@@ -175,7 +175,7 @@ def wait_for_volttron_startup(vhome, timeout):
     Wait for the VOLTTRON_PID file to be written.  Raises
     Exception if timeout is hit first.
     """
-    
+
     # Check for VOLTTRON_PID
     sleep_time = 0
     while (not is_volttron_running(vhome)) and sleep_time < timeout:


### PR DESCRIPTION
Changes to dependency injection container management, authentication service cleanup, and agent installation. 

- adding the ability to reset dependency injection containers for fresh test contexts
- ensuring clean shutdown of authentication resources
- clarifying agent credential creation. 
- minor cleanups and debugging improvements.

### Dependency Injection and Container Management

* Added a `reset_instances()` method to the `Container` class in `src/volttron/server/containers.py` to allow clearing all live-object caches and direct instance values, restoring the container to its class-registration state. This is crucial for test isolation and context switching. Supporting changes include tracking registrations in a new `_registrations` attribute and updating all registration methods to maintain this state. [[1]](diffhunk://#diff-c4bd43fd86289f53a3061b01ea47b072ca0e7c3ef281b2e09556cd2ac55db5c8R78-R81) [[2]](diffhunk://#diff-c4bd43fd86289f53a3061b01ea47b072ca0e7c3ef281b2e09556cd2ac55db5c8R440) [[3]](diffhunk://#diff-c4bd43fd86289f53a3061b01ea47b072ca0e7c3ef281b2e09556cd2ac55db5c8R457-R468) [[4]](diffhunk://#diff-c4bd43fd86289f53a3061b01ea47b072ca0e7c3ef281b2e09556cd2ac55db5c8R512-R546)
* Introduced a `reset_core_builder()` function in `src/volttron/client/decorators.py` to reset the cached core builder singleton, ensuring that subsequent calls create a fresh instance with empty state—important for test isolation.

### Authentication Service and Agent Installation

* Modified `AuthService` to remove the abstract `create_agent` method, replacing its usage with `create_credentials` during agent installation in `src/volttron/server/aip.py`, clarifying the agent credential creation process. [[1]](diffhunk://#diff-eae61063a85ed7c2e306bf816bb71b478acf8cac33aa061aaa26b7cfc0e4ee17L552-R552) [[2]](diffhunk://#diff-b783735406ba6632e352c7c3b6c2257bd7b7909fe605b86d40dc44dc0c51ab99L144-L146)
* Added a `stop()` method to the `Authenticator` interface in `src/volttron/types/auth/auth_service.py`, allowing implementations to clean up resources such as sockets or greenlets. The server shutdown logic in `src/volttron/server/run_server.py` now explicitly calls this method for clean resource release. [[1]](diffhunk://#diff-b783735406ba6632e352c7c3b6c2257bd7b7909fe605b86d40dc44dc0c51ab99R44-R63) [[2]](diffhunk://#diff-1b397999492e04840dcb6d444f580b8b399712d751cb11273f6ae151eade70e5R548-R556)

### Authorization and Debugging Improvements

* Improved error handling and debug output in the `get_protected_rpcs` method of `AgentAuthorization` by raising a detailed error if an invalid identity is encountered and printing a message when no capabilities are found.
* Minor cleanups: removed unnecessary debug prints in `status_agents` and commented out extraneous print statements in `subscribe_to_bus` to reduce console noise. [[1]](diffhunk://#diff-906bc870add3f41fa01a47e4e4086b6400796496b1ea6a32608d23e8e52607fcL637-L638) [[2]](diffhunk://#diff-a57b6cf8c7d5c08b46952dc92f6ced29fa4ac4d099f501e7cbb7544d6f329862L46-R46)